### PR TITLE
Add TypeScript and TSX file support

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -7,6 +7,7 @@ use std::collections::HashMap;
 #[derive(Debug, Clone, PartialEq)]
 pub enum Language {
     JavaScript,
+    TypeScript,
     Python,
     Rust,
 }
@@ -172,6 +173,29 @@ impl CodeOptimizer {
         self.rules.push(OptimizationRule {
             name: "use-strict-equality".to_string(),
             language: Language::JavaScript,
+            pattern_type: PatternType::Contains(" == ".to_string()),
+            replacement: " === ".to_string(),
+            explanation: "Use strict equality '===' to avoid type coercion bugs".to_string(),
+            severity: Severity::Warning,
+            confidence: 0.9,
+            enabled: true,
+        });
+
+        // TypeScript rules reuse JavaScript optimizations.
+        self.rules.push(OptimizationRule {
+            name: "use-const".to_string(),
+            language: Language::TypeScript,
+            pattern_type: PatternType::Contains("let ".to_string()),
+            replacement: "const ".to_string(),
+            explanation: "Use 'const' for variables that never change".to_string(),
+            severity: Severity::Info,
+            confidence: 0.8,
+            enabled: true,
+        });
+
+        self.rules.push(OptimizationRule {
+            name: "use-strict-equality".to_string(),
+            language: Language::TypeScript,
             pattern_type: PatternType::Contains(" == ".to_string()),
             replacement: " === ".to_string(),
             explanation: "Use strict equality '===' to avoid type coercion bugs".to_string(),
@@ -417,4 +441,14 @@ for item in items:
             println!("  ✨ Custom: {}", opt.explanation);
         }
     }
+    #[test]
+    fn test_typescript_analysis() {
+        let optimizer = CodeOptimizer::new();
+        let code = "let count: number = 1;\nif (count == 1) {}";
+        let optimizations = optimizer.analyze_code(code, Language::TypeScript);
+
+        assert!(optimizations.iter().any(|opt| opt.rule_name == "use-const"));
+        assert!(optimizations.iter().any(|opt| opt.rule_name == "use-strict-equality"));
+    }
+
 }

--- a/crates/optimizer-cli/src/main.rs
+++ b/crates/optimizer-cli/src/main.rs
@@ -32,7 +32,7 @@ fn main() {
             eprintln!(
                 "Error: Could not determine the programming language from the file extension."
             );
-            eprintln!("Supported extensions are: .js, .ts, .py, .rs");
+            eprintln!("Supported extensions are: .js, .ts, .tsx, .py, .rs");
             std::process::exit(1);
         }
     };
@@ -71,7 +71,8 @@ fn detect_language_from_path(path: &PathBuf) -> Option<Language> {
     let extension = path.extension()?.to_str()?;
 
     match extension {
-        "js" | "ts" => Some(Language::JavaScript),
+        "js" => Some(Language::JavaScript),
+        "ts" | "tsx" => Some(Language::TypeScript),
         "py" => Some(Language::Python),
         "rs" => Some(Language::Rust),
         _ => None,

--- a/editors/vscode/extension.js
+++ b/editors/vscode/extension.js
@@ -135,7 +135,7 @@ async function analyzeDocument(document, diagnosticCollection) {
 }
 
 function isSupported(languageId) {
-    return ['javascript', 'typescript', 'python', 'rust'].includes(languageId);
+    return ['javascript', 'javascriptreact', 'typescript', 'typescriptreact', 'python', 'rust'].includes(languageId);
 }
 
 function getSeverity(severity) {
@@ -159,7 +159,7 @@ async function simulateRustAnalysis(document) {
     
     lines.forEach((line, index) => {
         // Simulate JavaScript optimizations
-        if (document.languageId === 'javascript' || document.languageId === 'typescript') {
+        if (['javascript', 'javascriptreact', 'typescript', 'typescriptreact'].includes(document.languageId)) {
             if (line.includes('let ') && line.includes('=') && !line.includes('let i')) {
                 optimizations.push({
                     rule_name: 'use-const',

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -21,9 +21,10 @@
   ],
   "activationEvents": [
     "onLanguage:javascript",
+    "onLanguage:typescript",
+    "onLanguage:typescriptreact",
     "onLanguage:python",
-    "onLanguage:rust",
-    "onLanguage:typescript"
+    "onLanguage:rust"
   ],
   "main": "./out/extension.js",
   "contributes": {
@@ -49,7 +50,7 @@
         {
           "command": "codeOptimizer.analyzeFile",
           "group": "optimization",
-          "when": "resourceExtname =~ /\\.(js|ts|py|rs)$/"
+          "when": "resourceExtname =~ /\\.(js|jsx|ts|tsx|py|rs)$/"
         }
       ],
       "commandPalette": [


### PR DESCRIPTION
## Summary
- add TypeScript as a first-class core language
- map `.ts` and `.tsx` files in the CLI
- enable VS Code activation/context menu for TypeScript React (`.tsx`) and JavaScript React (`.jsx`)
- add a core test covering TypeScript suggestions

## Verification
- `cargo test --all` → 6 passed
- `npm --prefix editors/vscode test` → no test script defined in package.json

Closes #1